### PR TITLE
Add themer@3 to peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch": "^1.0.1"
   },
   "peerDependencies": {
-    "themer": "^1.0.2||^2"
+    "themer": "^1.0.2||^2||^3"
   },
   "bugs": {
     "url": "https://github.com/tomselvi/themer-jetbrains/issues"


### PR DESCRIPTION
themer-jetbrains is compatible with themer@3, so adding this will remove peer dependency warnings upon install.